### PR TITLE
Added missing <=

### DIFF
--- a/x86_sim.cpp
+++ b/x86_sim.cpp
@@ -438,7 +438,7 @@ bool X86Sim::translateVirtualToPhysical(uint32_t vaddr, uint32_t &paddr)
 {
     if (vaddr >= X_VIRTUAL_GLOBAL_START_ADDR && vaddr <= X_VIRTUAL_GLOBAL_END_ADDR) {
         paddr = vaddr - X_VIRTUAL_GLOBAL_START_ADDR;
-    } else if (vaddr >= stack_start_address && vaddr < X_VIRTUAL_STACK_END_ADDR) {
+    } else if (vaddr >= stack_start_address && vaddr <= X_VIRTUAL_STACK_END_ADDR) {
         paddr = (vaddr - stack_start_address) + (X_GLOBAL_MEM_WORD_COUNT * 4);
     } else {
         reportError("Runtime exception: fetch address out of limit 0x%x\n", vaddr);


### PR DESCRIPTION
Había un bug que sucedía cuando se utilizaba un `#show dword` del último elemento del stack. 

**Ejemplo:**

```
push 10
#show dword [esp]
add esp, 4
```

**Output:**

```
dword [0x7fffeff8] = 10
Line 2: Runtime exception: fetch address out of limit 0x7fffeffc
Line 2: Invalid address '0x7FFFEFFC'.
```

Sí imprimía el valor que estaba guardado en el stack pero luego ocurría un error.
